### PR TITLE
Corrected typo in bibliography

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -17,7 +17,7 @@
   year={1999},
   edition={2nd},
   publisher={Prentice-Hall},
-  address = {Englewood Cliffs, NJ}m
+  address = {Englewood Cliffs, NJ},
   isbn = {0-13-656695-2}
 }
 


### PR DESCRIPTION
Accidental `m` replaced with comma