### PR TITLE
Release v0.0.6.1: sysidentpy compatibility fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,15 @@ PYDAQ requires:
 - numpy (>=1.22.3) to process data
 - PySide6 (>=6.7.1), PySide6_Addons, PySide6_Essentials and shiboken6 as a Graphical User Interface framework
 - pyserial (>=3.5) to manage data to/from Arduino
-- sysidentpy (==0.3.4) and bitarray (>=3.0.0) for model acquisition/signal generation
+- sysidentpy (>=0.4.1) and bitarray (>=3.0.0) for model acquisition/signal generation
 - packaging (>=24.1)
 - scipy (>=1.16.1) for digital filters and PID Control.
 
-**NOTE 1:** In this version of pydaq (0.0.6), [(NI-DAQmx drivers)](https://www.ni.com/en/support/downloads/drivers/download.ni-daq-mx.html#494676) must be installed, even if 
+**NOTE 1:** In this version of pydaq (0.0.6.1), [(NI-DAQmx drivers)](https://www.ni.com/en/support/downloads/drivers/download.ni-daq-mx.html#494676) must be installed, even if 
 the user is only using Arduino Boards. This issue will be addressed in future versions, allowing
 Arduino users to use PYDAQ without having to install NI-DAQmx drivers.
 
-**NOTE 2:** PYDAQ is fully tested up to Python 3.11. It may run on versions above this, but without guarantees. 
+**NOTE 2:** PYDAQ is fully tested up to Python 3.14. It may run on versions above this, but without guarantees. 
 
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,11 +33,11 @@ PYDAQ requires:
 * `numpy (>=1.22.3)` for numerical processing
 * `PySide6 (>=6.7.1)`, `PySide6_Addons`, `PySide6_Essentials`, and `shiboken6` for the graphical user interface
 * `pyserial (>=3.5)` for communication with Arduino boards
-* `sysidentpy (==0.3.4)` and `bitarray (>=3.0.0)` for system identification and signal generation
+* `sysidentpy (>=0.4.1)` and `bitarray (>=3.0.0)` for system identification and signal generation
 * `packaging (>=24.1)`
 * `scipy (>=1.16.1)` for digital filters and PID control
 
-**Note:** In version **v0.0.6**, NI-DAQmx drivers must be installed even if only Arduino boards are used. This limitation will be addressed in future releases.
+**Note:** In version **v0.0.6.1**, NI-DAQmx drivers must be installed even if only Arduino boards are used. This limitation will be addressed in future releases.
 
 ---
 

--- a/pydaq/get_model.py
+++ b/pydaq/get_model.py
@@ -17,7 +17,8 @@ import queue
 from pydaq.utils.signals import Signal
 from math import floor
 from sysidentpy.model_structure_selection import FROLS
-from sysidentpy.basis_function._basis_function import Polynomial
+#from sysidentpy.basis_function._basis_function import Polynomial
+from sysidentpy.basis_function import Polynomial
 from sysidentpy.metrics import root_relative_squared_error
 from sysidentpy.utils.display_results import results
 from sysidentpy.utils.plotting import plot_residues_correlation, plot_results
@@ -27,6 +28,9 @@ from sysidentpy.residues.residues_correlation import (
 )
 from collections import Counter
 from typing import Tuple
+
+from sysidentpy.parameter_estimation import LeastSquares
+
 
 mpl.rcParams["axes.spines.right"] = False
 mpl.rcParams["axes.spines.top"] = False
@@ -461,10 +465,14 @@ class GetModel(Base):
 
         basis_function = Polynomial(degree=self.degree)
 
+        if self.ext_lsq:
+            self.estimator = LeastSquares(unbiased=True)
+        elif self.estimator is None or isinstance(self.estimator, str):
+            self.estimator = LeastSquares(unbiased=False)
+
         model = FROLS(
             order_selection=True,
             n_info_values=self.num_info_val,
-            extended_least_squares=self.ext_lsq,
             ylag=[i + 1 for i in range(self.inp_lag)],
             xlag=[i + 1 for i in range(self.out_lag)],
             info_criteria="aic",
@@ -584,10 +592,14 @@ class GetModel(Base):
 
         basis_function = Polynomial(degree=self.degree)
 
+        if self.ext_lsq:
+            self.estimator = LeastSquares(unbiased=True)
+        elif self.estimator is None or isinstance(self.estimator, str):
+            self.estimator = LeastSquares(unbiased=False)
+
         model = FROLS(
             order_selection=True,
             n_info_values=self.num_info_val,
-            extended_least_squares=self.ext_lsq,
             ylag=[i + 1 for i in range(self.inp_lag)],
             xlag=[i + 1 for i in range(self.out_lag)],
             info_criteria="aic",
@@ -618,6 +630,7 @@ class GetModel(Base):
 
         ee = compute_residues_autocorrelation(y_valid, yhat)
         x1e = compute_cross_correlation(y_valid, yhat, x_valid)
+
         metrics_df = dict()
         metrics_namelist = list()
         metrics_vallist = list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydaq"
-version = "0.0.6"
+version = "0.0.6.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
 keywords = ["Python", "Data Acquisition", "Arduino", "NIDAQ"]
@@ -32,7 +32,7 @@ classifiers = [
 ] 
 dependencies = ["numpy", "nidaqmx", "matplotlib",
     "pyserial", "packaging", "PySide6",
-    "PySide6_Addons", "PySide6_Essentials", "shiboken6", "sysidentpy==0.3.4", "bitarray", "scipy"]
+    "PySide6_Addons", "PySide6_Essentials", "shiboken6", "sysidentpy>=0.4.1", "bitarray", "scipy"]
 
 [project.urls]
 homepage = "https://pydaq.org/"


### PR DESCRIPTION
## Description
This pull request introduces version **v0.0.6.1** of PYDAQ.

The main goal of this update is to restore compatibility with newer versions of `sysidentpy` and modern Python environments. Previously, installing PYDAQ in newer environments could lead to unintended behavior (e.g., fallback to older versions) due to strict dependency constraints.

This update adapts the codebase to the newer `sysidentpy` API while aiming to preserve the behavior of existing data acquisition workflows and model identification processes.

## Main Changes

* **Dependency Update:**
  - Updated `sysidentpy` from `==0.3.4` to `>=0.4.1`.

* **Compatibility Fixes:**
  - Adjusted the usage of `FROLS` to match the updated API.
  - Removed the deprecated parameter `extended_least_squares`.
  - Updated estimator handling to align with the new versions.

* **Python Compatibility:**
  - Improved compatibility with newer Python versions (>=3.11).

* **Documentation:**
  - Updated `README.md`, `docs/index.md`, and environment configuration files to reflect version `v0.0.6.1` and the new dependency constraints.